### PR TITLE
Implement parameterized key-value storage using arrays

### DIFF
--- a/src/main/java/core/basesyntax/impl/StorageImpl.java
+++ b/src/main/java/core/basesyntax/impl/StorageImpl.java
@@ -1,19 +1,56 @@
 package core.basesyntax.impl;
 
 import core.basesyntax.Storage;
+import java.util.Objects;
 
 public class StorageImpl<K, V> implements Storage<K, V> {
+    private static final int MAX_ITEMS_NUMBER = 10;
+    private final Object[] keys;
+    private final Object[] values;
+    private int size = 0;
+
+    public StorageImpl() {
+        this.keys = new Object[MAX_ITEMS_NUMBER];
+        this.values = new Object[MAX_ITEMS_NUMBER];
+    }
+
     @Override
     public void put(K key, V value) {
+        int keyIndex = getKeyIndex(key);
+        if (keyIndex != -1) {
+            values[keyIndex] = value;
+            return;
+        }
+
+        if (size < MAX_ITEMS_NUMBER) {
+            keys[size] = key;
+            values[size] = value;
+            size++;
+        } else {
+            throw new RuntimeException("Storage is full!");
+        }
+    }
+
+    private int getKeyIndex(K keyToCompare) {
+        for (int i = 0; i < size; i++) {
+            if (Objects.equals(keys[i], keyToCompare)) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     @Override
     public V get(K key) {
-        return null;
+        int index = getKeyIndex(key);
+        if (index == -1) {
+            return null;
+        }
+        return (V) values[index];
     }
 
     @Override
     public int size() {
-        return -1;
+        return size;
     }
 }


### PR DESCRIPTION
This commit implements a Storage interface for key-value pairs, where keys are of type Integer and values are of type Box. The StorageImpl class utilizes one or two arrays, depending on the implementation. When adding a new key-value pair using the put method, if the key already exists, the value is replaced. The get method retrieves the value associated with a given key. Additionally, the size method returns the current size of the storage.