### PR TITLE
initial solution

### DIFF
--- a/src/main/java/core/basesyntax/impl/StorageImpl.java
+++ b/src/main/java/core/basesyntax/impl/StorageImpl.java
@@ -1,19 +1,58 @@
 package core.basesyntax.impl;
 
 import core.basesyntax.Storage;
+import java.util.Arrays;
 
 public class StorageImpl<K, V> implements Storage<K, V> {
-    @Override
-    public void put(K key, V value) {
+    private static final int MAX_SIZE = 10;
+    private final Object[] keys = new Object[MAX_SIZE];
+    private final Object[] values = new Object[MAX_SIZE];
+
+    private static Object[] removeNull(Object[] arr1, Object[] arr2) {
+        int newSize = 0;
+        for (int i = 0; i < MAX_SIZE; i++) {
+            if (arr1[i] != null || arr2[i] != null) {
+                arr1[newSize++] = arr1[i];
+            }
+        }
+
+        return Arrays.copyOf(arr1, newSize);
     }
 
-    @Override
-    public V get(K key) {
+    private Object indexOf(Object[] keys, Object key) {
+        for (int i = 0; i < keys.length; i++) {
+            if (keys[i] == key || (keys[i] != null && keys[i].equals(key))) {
+                return i;
+            }
+        }
         return null;
     }
 
     @Override
+    public void put(K key, V value) {
+        for (int i = 0; i < MAX_SIZE; i++) {
+            if (keys[i] == key || (keys[i] != null && keys[i].equals(key))) {
+                values[i] = value;
+                break;
+            } else if (keys[i] == null && values[i] == null) {
+                keys[i] = key;
+                values[i] = value;
+                break;
+            }
+        }
+    }
+
+    @Override
+    public V get(K key) {
+        Object[] trimmedKeys = removeNull(keys, values);
+        Object[] trimmedValues = removeNull(values, keys);
+        Object index = indexOf(trimmedKeys, key);
+        return index == null ? null : (V) trimmedValues[(int) index];
+    }
+
+    @Override
     public int size() {
-        return -1;
+        Object[] trimmedKeys = removeNull(keys, values);
+        return trimmedKeys.length;
     }
 }


### PR DESCRIPTION
Why is using Objects class (specifically its .equals method) considered a mistake according to the Common mistakes section? It would have allowed me to simplify this condition - keys[i] == key || (keys[i] != null && keys[i].equals(key)), if it weren't prohibited